### PR TITLE
no content-type meta at index

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <head>
-    <meta http-equiv="content" content="type=text/html, charset=UTF-8">
     <meta name="author" content="uryelah & santiago-rodrig">
     <meta name="description" content="A clone for the signup form of Mint.com">
     <meta charset="utf-8">


### PR DESCRIPTION
Hey Sarah, I thought we deleted the content meta because of the redundancy with the charset meta, anyway, I changed that, review the index.html and let me know if everything is good to go for a merge.